### PR TITLE
Linux Install Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Free, feature-rich, gui-integrated geometry dash mod menu
 
 Download the latest [release](https://github.com/maxnut/GDMegaOverlay/releases/latest) and extract all files inside the GD folder.
 
+Additional steps to run on Linux: Go to `Steam Library` -> Right click Geometry Dash -> `Properties` -> `General` -> `Launch Options` and add `WINEDLLOVERRIDES="xinput9_1_0=n,b" %command%`
+
 ## Development
 
 <span style="color:red">THIS PROJECT CAN BE COMPILED ONLY ON WINDOWS</span>


### PR DESCRIPTION
When I tried installing the mod on my linux machine, the provided instructions of just copying all files into the GD folder sadly did not work for me. There was a similar situation with another game I play but that one had instructions on how to set it up on Linux, those being to add some kind of override for a modified DLL (not sure what exactly it does though but it changes from where the DLL is loaded I think). I just reused that patch and applied it to GD but with the name of the modified DLL changed to xinput_9_1_0, which is responsible for loading this mod if I got that correctly.

This *should* work without issues but it would really be helpful if someone else running linux could try this.