### PR TITLE
Fix endscreen settings

### DIFF
--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -1074,7 +1074,10 @@ void Hacks::RenderMain()
 		if (ImGui::ArrowButton("sei", 1))
 			ImGui::OpenPopup("Endscreen Settings");
 
-		if (ImGui::BeginPopupModal("Endscreen Settings", NULL, ImGuiWindowFlags_AlwaysAutoResize) || ExternData::fake)
+		// ImGuiWindowFlags_AlwaysAutoResize doesn't work, so we specify the popup size manually
+		const float scale = ImGui::GetIO().DisplaySize.x / 1920;
+		ImGui::SetNextWindowSize(ImVec2(150 * scale, 170 * scale));
+		if (ImGui::BeginPopupModal("Endscreen Settings", NULL, ImGuiWindowFlags_NoResize) || ExternData::fake)
 		{
 			GDMO::ImCheckbox("Safe Mode", &hacks.safeModeEndscreen);
 			GDMO::ImCheckbox("Practice Button", &hacks.practiceButtonEndscreen);


### PR DESCRIPTION
This PR fixes the endscreen settings being cut off, here's an image of how it looks like:
![broken image](https://github.com/maxnut/GDMegaOverlay/assets/61124550/44dab1dd-62e1-454e-af17-d491699ee384)
And here is how it looks after the PR:
![fixed image](https://github.com/maxnut/GDMegaOverlay/assets/61124550/32821577-f80a-49cf-9632-41a8d3d42ce2)


