### PR TITLE
Add 12h clock support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -87,6 +87,9 @@
         "csignal": "cpp",
         "future": "cpp",
         "random": "cpp",
-        "regex": "cpp"
+        "regex": "cpp",
+        "codecvt": "cpp",
+        "coroutine": "cpp",
+        "resumable": "cpp"
     }
 }

--- a/src/PlayLayer.cpp
+++ b/src/PlayLayer.cpp
@@ -699,7 +699,12 @@ void UpdateLabels(gd::PlayLayer* self)
 		auto t = std::time(nullptr);
 		auto tm = *std::localtime(&t);
 		std::ostringstream s;
+		if (!hacks.use12hFormat) 
+		{
 		s << std::put_time(&tm, "%H:%M:%S");
+		} else {
+			s << std::put_time(&tm, "%I:%M:%S %p");
+		}
 
 		fontPtr->setString(s.str().c_str());
 

--- a/src/bools.h
+++ b/src/bools.h
@@ -123,6 +123,8 @@ struct HacksStr
 
 	bool realPercentage;
 	float levelEndPercent;
+
+	bool use12hFormat = false;
 };
 
 enum position

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -1371,6 +1371,7 @@ void Hacks::RenderMain()
 		if (ImGui::BeginPopupModal("Clock Settings", NULL, ImGuiWindowFlags_AlwaysAutoResize) || ExternData::fake)
 		{
 			TextSettings(5, true);
+			GDMO::ImCheckbox("Use 12h format", &hacks.use12hFormat);
 			if (GDMO::ImButton("Close", false))
 			{
 				ImGui::CloseCurrentPopup();


### PR DESCRIPTION
This PR adds 12h clock support for the clock status label.
![image](https://github.com/maxnut/GDMegaOverlay/assets/61124550/93b0e050-47b9-40a8-8700-9aeac7000240)
![image](https://github.com/maxnut/GDMegaOverlay/assets/61124550/632bdb1e-986d-474e-b862-d64a7729f382)
