### PR TITLE
Fix no network crash

### DIFF
--- a/src/Updater.cpp
+++ b/src/Updater.cpp
@@ -84,6 +84,8 @@ void Updater::CheckUpdate()
 		res = curl_easy_perform(curl);
 		curl_easy_cleanup(curl);
 
+		if (res != CURLE_OK) return;
+
 		std::string info = readBuffer.c_str();
 		savedRequest = json::parse(info);
 


### PR DESCRIPTION
This fixes the crash from the auto-updater, which happened if there was a lack of an internet connection.