### PR TITLE
Add wget support, making it possible to download MP3s via a direct download link

### DIFF
--- a/src/Hacks.h
+++ b/src/Hacks.h
@@ -537,9 +537,20 @@ static void NongDownload(char* url, char* id)
 	std::thread([&, url, id]() {
 		{
 			std::stringstream stream;
+			
+			string youtubeURL = "youtube.com"
+			string mp3ext = ".mp3"
+			
+			bool isYoutube = url.find(youtubeURL) != string::npos;
 
-			stream << "GDMenu/yt-dlp -f bestaudio[ext=m4a] --output audiofile.m4a " << url;
-
+			if (isYoutube)
+			{
+				stream << "GDMenu/yt-dlp -f bestaudio[ext=m4a] --output audiofile.m4a " << url;
+			}
+			else
+			{
+				stream << "GDMenu/wget -O audiofile.m4a " << url;
+			}
 			auto process = subprocess::Popen(stream.str());
 			if (process.close())
 			{


### PR DESCRIPTION
The code checks if it's a youtube link via scanning for the string "youtube.com", if so it calls yt-dlp as normal. However, if the string is not found, it calls wget instead.

The binaries and dependencies for wget that would need to be bundled with GDMO to work can be found [here](https://cytranet.dl.sourceforge.net/project/gnuwin32/wget/1.11.4-1/wget-1.11.4-1-bin.zip) and [here](https://versaweb.dl.sourceforge.net/project/gnuwin32/wget/1.11.4-1/wget-1.11.4-1-dep.zip), respectively.

I have not been able to build GDMO so I cannot test my code yet.